### PR TITLE
Refactor monetário: migrar Double restantes para BigDecimal

### DIFF
--- a/app/src/main/java/com/migueldk17/breeze/BreezeDatabase.kt
+++ b/app/src/main/java/com/migueldk17/breeze/BreezeDatabase.kt
@@ -13,7 +13,7 @@ import com.migueldk17.breeze.data.local.entity.ParcelaEntity
 import com.migueldk17.breeze.data.local.entity.MovimentacaoEntity
 
 
-@Database(entities = [Conta::class, MovimentacaoEntity::class, ParcelaEntity::class], version = 19, exportSchema = true)
+@Database(entities = [Conta::class, MovimentacaoEntity::class, ParcelaEntity::class], version = 20, exportSchema = true)
 @TypeConverters(TipoMovimentacaoConverter::class, BigDecimalConverter::class)
 abstract class BreezeDatabase: RoomDatabase() {
 

--- a/app/src/main/java/com/migueldk17/breeze/MoneyVisualTransformation.kt
+++ b/app/src/main/java/com/migueldk17/breeze/MoneyVisualTransformation.kt
@@ -5,14 +5,16 @@ import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
 import java.util.Locale
+import java.math.BigDecimal
+import java.math.RoundingMode
 
 class MoneyVisualTransformation : VisualTransformation {
     override fun filter(text: AnnotatedString): TransformedText {
         val cleanText = text.text.filter { it.isLetterOrDigit() }
-        val value = cleanText.toDoubleOrNull() ?: 0.0
+        val value = cleanText.toBigDecimalOrNull() ?: BigDecimal.ZERO
 
         //Formata o valor como moeda (R$ 0,00)
-        val formattedValue = String.format(Locale.getDefault(),"R$: %.2f", value / 100)
+        val formattedValue = String.format(Locale.getDefault(),"R$: %.2f", value.divide(BigDecimal(100), 2, RoundingMode.HALF_EVEN))
         val offsetMapping = object : OffsetMapping {
             override fun originalToTransformed(offset: Int): Int {
                 return formattedValue.length

--- a/app/src/main/java/com/migueldk17/breeze/domain/MovimentacaoDomain.kt
+++ b/app/src/main/java/com/migueldk17/breeze/domain/MovimentacaoDomain.kt
@@ -4,13 +4,14 @@ import androidx.room.ColumnInfo
 import androidx.room.PrimaryKey
 import com.github.migueldk17.breezeicons.icons.BreezeIconsType
 import com.migueldk17.breeze.enums.TipoMovimentacao
+import java.math.BigDecimal
 import java.time.LocalDate
 
 data class MovimentacaoDomain(
 
     val id: Long = 0L,
 
-    val valor: Double,
+    val valor: BigDecimal,
 
     val descricao: String,
 

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/models/DadosContaUI.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/models/DadosContaUI.kt
@@ -2,6 +2,7 @@ package com.migueldk17.breeze.ui.features.adicionarconta.models
 
 import androidx.compose.ui.graphics.Color
 import com.github.migueldk17.breezeicons.icons.BreezeIconsType
+import java.math.BigDecimal
 import java.time.LocalDate
 
 data class DadosContaUI(
@@ -9,12 +10,12 @@ data class DadosContaUI(
     val icone: BreezeIconsType,
     val corIcone: Color,
     val corCard: Color,
-    val valor: Double,
+    val valor: BigDecimal,
     val categoria: String,
     val subCategoria: String,
-    val valorParcela: Double,
+    val valorParcela: BigDecimal,
     val totalParcelas: Int,
     val data: LocalDate,
     val isParcelada: Boolean,
-    val taxaJuros: Double
+    val taxaJuros: BigDecimal
 )

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/ui/components/PassoColumnPai.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/ui/components/PassoColumnPai.kt
@@ -1,0 +1,18 @@
+package com.migueldk17.breeze.ui.features.adicionarconta.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+
+@Composable
+fun PassoColumnPai(
+    modifier: Modifier = Modifier,
+    composable: @Composable () -> Unit
+){
+    Column(
+        modifier = modifier
+    ) {
+        composable
+    }
+}

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/ui/layouts/Final.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/ui/layouts/Final.kt
@@ -34,6 +34,7 @@ import com.migueldk17.breeze.ui.features.paginainicial.ui.components.avançaMain
 import com.migueldk17.breeze.ui.utils.formataSaldo
 import com.migueldk17.breeze.ui.utils.formataTaxaDeJuros
 import kotlinx.collections.immutable.persistentMapOf
+import java.math.BigDecimal
 
 
 @Composable
@@ -130,8 +131,8 @@ fun Final(
     }
 }
 
-private fun retornaValorFinal(valorFixo: Double, valorParcela: Double, totalParcelas: Int): String {
-   val valorFinal = if(valorParcela == 0.00){
+private fun retornaValorFinal(valorFixo: BigDecimal, valorParcela: BigDecimal, totalParcelas: Int): String {
+   val valorFinal = if (valorParcela.compareTo(BigDecimal.ZERO) == 0) {
         formataSaldo(valorFixo)
     } else {
         //Caso o valor de parcela esteja preenchido se espera que total parcelas obviamente também esteja

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/ui/layouts/Final.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/ui/layouts/Final.kt
@@ -61,16 +61,16 @@ fun Final(
                 dadosDaConta.valorParcela,
                 dadosDaConta.totalParcelas
             ),
-            "Valor da parcela" to formataSaldo(dadosDaConta.valorParcela),
+            "Valor da parcela" to dadosDaConta.valorParcela.toPlainString(),
             "Data de vencimento" to dataFormatada,
-            "Taxa de juros" to "${formataTaxaDeJuros(porcentagemJuros)} a.m"
+           "Taxa de juros" to "${formataTaxaDeJuros(porcentagemJuros)} a.m"
         )
     } else {
         persistentMapOf(
             "Nome" to dadosDaConta.nome,
             "Categoria" to dadosDaConta.categoria,
             "Sub Categoria" to dadosDaConta.subCategoria,
-            "Valor Total" to formataSaldo(dadosDaConta.valor),
+            "Valor Total" to dadosDaConta.valor.toPlainString(),
             "Data de vencimento" to dataFormatada
         )
     }

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/ui/layouts/Passo1.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/ui/layouts/Passo1.kt
@@ -33,6 +33,7 @@ import com.migueldk17.breeze.ui.components.BreezeDropdownMenu
 import com.migueldk17.breeze.ui.components.BreezeOutlinedTextField
 import com.migueldk17.breeze.ui.components.InfoIconWithPopup
 import com.migueldk17.breeze.ui.components.DescriptionText
+import com.migueldk17.breeze.ui.features.adicionarconta.ui.components.PassoColumnPai
 import com.migueldk17.breeze.ui.features.adicionarconta.ui.components.PersonalizationCard
 import com.migueldk17.breeze.ui.features.adicionarconta.ui.components.SubcategoryChipGroup
 import com.migueldk17.breeze.ui.features.adicionarconta.viewmodels.AdicionarContaViewModel
@@ -88,9 +89,11 @@ fun Passo1(
     val focusManager = LocalFocusManager.current
 
 
-
-    Column(
+    PassoColumnPai(
         modifier = modifier
+    ) { }
+    Column(
+        modifier = Modifier
             .padding(25.dp)
             .pointerInput(Unit){
                 detectTapGestures {
@@ -187,7 +190,7 @@ private fun textoCorreto(text: String): Boolean {
 private fun isBreezeButtonEnabled(text: String, categorySelected: String, subcategorySelected: String): Boolean {
     val verificacaoText = text.isNotEmpty() && textoCorreto(text)
     val verificacaoCategory = categorySelected.isNotEmpty() && categorySelected != "Selecione uma categoria"
-    val verificacaoSubCategory = verificacaoCategory == true && subcategorySelected.isNotEmpty()
+    val verificacaoSubCategory = verificacaoCategory && subcategorySelected.isNotEmpty()
 
     return verificacaoText && verificacaoCategory && verificacaoSubCategory
 }

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/ui/layouts/Passo2.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/ui/layouts/Passo2.kt
@@ -30,12 +30,15 @@ import com.migueldk17.breeze.ui.theme.blackPoppinsLightMode
 fun Passo2(
     navToPasso3: () -> Unit,
     currentState: String?,
+    modifier: Modifier = Modifier,
     viewModel: AdicionarContaViewModel = hiltViewModel()){
     val nomeConta = viewModel.nomeConta.collectAsStateWithLifecycle().value
 
 
     //Column do Passo2
-    Column {
+    Column(
+        modifier = modifier
+    ) {
         Column(
             modifier = Modifier
                 .padding(25.dp),
@@ -49,7 +52,7 @@ fun Passo2(
 
             Spacer(modifier = Modifier.size(26.dp))
 
-            DescriptionText("Agora escolha um nome para representar essa conta.")
+            DescriptionText("Agora escolha um ícone para representar essa conta.")
             Spacer(Modifier.size(18.dp))
             Text("Qual combina melhor ?",
                 style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/ui/layouts/Passo4.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/ui/layouts/Passo4.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
@@ -36,6 +37,8 @@ import com.migueldk17.breeze.ui.features.adicionarconta.ui.components.Personaliz
 import com.migueldk17.breeze.ui.features.adicionarconta.ui.components.ResponsiveDateParcelaSection
 import com.migueldk17.breeze.ui.features.adicionarconta.viewmodels.AdicionarContaViewModel
 import com.migueldk17.breeze.ui.features.paginainicial.ui.components.BreezeDatePicker
+import com.migueldk17.breeze.ui.utils.ToastManager
+import com.migueldk17.breeze.ui.utils.parseCentavos
 import java.math.BigDecimal
 import java.time.LocalDate
 
@@ -45,6 +48,7 @@ fun Passo4(
     navToPasso5: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: AdicionarContaViewModel = hiltViewModel()) {
+    val context = LocalContext.current
     //Valor bruto da conta em reais
     var valorConta by remember{
         mutableStateOf("")
@@ -110,7 +114,6 @@ fun Passo4(
                 onValueChange = { text ->
                     valorConta = text
                         .filter { it.isDigit() }
-
                 },
                 textLabel = "Adicionar Valor",
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal, imeAction = ImeAction.Done),
@@ -172,12 +175,9 @@ fun Passo4(
                     .padding(vertical = 74.dp),
                 text = "Avançar",
                 onClick = {
-                    val valorBigDecimal = valorConta
-                        .replace(".", "")
-                        .replace(",", ".")
-                        .toBigDecimalOrNull()
-                        ?: BigDecimal.ZERO
+                    val valorBigDecimal = parseCentavos(valorConta)
                     viewModel.guardaValorConta(valorBigDecimal)
+                    Log.d(TAG, "Passo4: $textJuros")
                     if (textJuros != "") viewModel.guardaPorcentagemJuros(textJuros) //Guarda a porcentagem de juros
                     viewModel.guardaDataConta(selectedDate) //Guarda a data da conta
                     if (textParcelas.isEmpty()) viewModel.guardaQtdParcelas(selectedCategory) else viewModel.guardaQtdParcelas(textParcelas) //Guarda a quantidade de parcelas
@@ -193,10 +193,8 @@ fun Passo4(
                 )
             )
         }
-
-
-        }
     }
+}
 //Função usada para controlar o estado do BreezeButton
 @Composable
 private fun buttonAvancaEnabled(

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/ui/layouts/Passo4.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/ui/layouts/Passo4.kt
@@ -108,7 +108,8 @@ fun Passo4(
                 modifier = Modifier.fillMaxWidth(),
                 text = valorConta,
                 onValueChange = { text ->
-                    valorConta = text.filter { it.isDigit() }
+                    valorConta = text
+                        .filter { it.isDigit() }
 
                 },
                 textLabel = "Adicionar Valor",
@@ -171,7 +172,12 @@ fun Passo4(
                     .padding(vertical = 74.dp),
                 text = "Avançar",
                 onClick = {
-                    viewModel.guardaValorConta(BigDecimal(valorConta))
+                    val valorBigDecimal = valorConta
+                        .replace(".", "")
+                        .replace(",", ".")
+                        .toBigDecimalOrNull()
+                        ?: BigDecimal.ZERO
+                    viewModel.guardaValorConta(valorBigDecimal)
                     if (textJuros != "") viewModel.guardaPorcentagemJuros(textJuros) //Guarda a porcentagem de juros
                     viewModel.guardaDataConta(selectedDate) //Guarda a data da conta
                     if (textParcelas.isEmpty()) viewModel.guardaQtdParcelas(selectedCategory) else viewModel.guardaQtdParcelas(textParcelas) //Guarda a quantidade de parcelas

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/ui/layouts/Passo4.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/ui/layouts/Passo4.kt
@@ -168,7 +168,7 @@ fun Passo4(
                     .padding(vertical = 74.dp),
                 text = "Avançar",
                 onClick = {
-                    viewModel.guardaValorConta(valorConta.toDouble())
+                    viewModel.guardaValorConta(valorConta)
                     if (textJuros != "") viewModel.guardaPorcentagemJuros(textJuros) //Guarda a porcentagem de juros
                     viewModel.guardaDataConta(selectedDate) //Guarda a data da conta
                     if (textParcelas.isEmpty()) viewModel.guardaQtdParcelas(selectedCategory) else viewModel.guardaQtdParcelas(textParcelas) //Guarda a quantidade de parcelas

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/ui/layouts/Passo4.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/ui/layouts/Passo4.kt
@@ -36,6 +36,7 @@ import com.migueldk17.breeze.ui.features.adicionarconta.ui.components.Personaliz
 import com.migueldk17.breeze.ui.features.adicionarconta.ui.components.ResponsiveDateParcelaSection
 import com.migueldk17.breeze.ui.features.adicionarconta.viewmodels.AdicionarContaViewModel
 import com.migueldk17.breeze.ui.features.paginainicial.ui.components.BreezeDatePicker
+import java.math.BigDecimal
 import java.time.LocalDate
 
 @SuppressLint("UnusedBoxWithConstraintsScope")
@@ -76,7 +77,9 @@ fun Passo4(
     val corIcone = viewModel.corIcone.collectAsStateWithLifecycle().value
 
     //Column do Passo4
-    BoxWithConstraints{
+    BoxWithConstraints(
+        modifier = modifier
+    ){
         val horizontalPadding = if (maxWidth < 380.dp) 16.dp else 25.dp //Padding responsivo de acordo com a largura da tela
         val isSmallScreen = maxWidth < 380.dp //Boolean que controla se a tela é pequena ou não
         var showDatePicker by remember { mutableStateOf(false)}
@@ -168,7 +171,7 @@ fun Passo4(
                     .padding(vertical = 74.dp),
                 text = "Avançar",
                 onClick = {
-                    viewModel.guardaValorConta(valorConta)
+                    viewModel.guardaValorConta(BigDecimal(valorConta))
                     if (textJuros != "") viewModel.guardaPorcentagemJuros(textJuros) //Guarda a porcentagem de juros
                     viewModel.guardaDataConta(selectedDate) //Guarda a data da conta
                     if (textParcelas.isEmpty()) viewModel.guardaQtdParcelas(selectedCategory) else viewModel.guardaQtdParcelas(textParcelas) //Guarda a quantidade de parcelas

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/ui/layouts/Passo5.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/ui/layouts/Passo5.kt
@@ -22,7 +22,6 @@ import com.migueldk17.breeze.ui.features.adicionarconta.ui.components.adicionaCo
 import com.migueldk17.breeze.ui.features.adicionarconta.ui.components.carrouselIcons
 import com.migueldk17.breeze.ui.features.adicionarconta.ui.components.insereIconeNoViewModel
 import com.migueldk17.breeze.ui.features.adicionarconta.viewmodels.AdicionarContaViewModel
-import com.migueldk17.breeze.ui.utils.formataValorConta
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.migueldk17.breeze.ui.utils.formatarValorEmReal
 import java.math.BigDecimal
@@ -40,6 +39,7 @@ fun Passo5(
     val valorConta = viewModel.valorConta.collectAsStateWithLifecycle().value
     //Pega o valor da conta do viewModel e formata para valores monetários
     val valorMascarado = valorConta.formatarValorEmReal()
+
 
 
     Column(

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/ui/layouts/Passo5.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/ui/layouts/Passo5.kt
@@ -24,11 +24,13 @@ import com.migueldk17.breeze.ui.features.adicionarconta.ui.components.insereIcon
 import com.migueldk17.breeze.ui.features.adicionarconta.viewmodels.AdicionarContaViewModel
 import com.migueldk17.breeze.ui.utils.formataValorConta
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import java.math.BigDecimal
 
 @Composable
 fun Passo5(
     navToFinal: () -> Unit,
     currentState: String?,
+    modifier: Modifier = Modifier,
     viewModel: AdicionarContaViewModel = hiltViewModel()) {
 
     val nomeConta = viewModel.nomeConta.collectAsStateWithLifecycle().value
@@ -39,7 +41,9 @@ fun Passo5(
     val valorMascarado = formataValorConta(valorConta)
 
 
-    Column {
+    Column(
+        modifier = modifier
+    ) {
         //Column do Passo5
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/ui/layouts/Passo5.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/ui/layouts/Passo5.kt
@@ -24,6 +24,7 @@ import com.migueldk17.breeze.ui.features.adicionarconta.ui.components.insereIcon
 import com.migueldk17.breeze.ui.features.adicionarconta.viewmodels.AdicionarContaViewModel
 import com.migueldk17.breeze.ui.utils.formataValorConta
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.migueldk17.breeze.ui.utils.formatarValorEmReal
 import java.math.BigDecimal
 
 @Composable
@@ -38,7 +39,7 @@ fun Passo5(
     val corIcone = viewModel.corIcone.collectAsStateWithLifecycle().value
     val valorConta = viewModel.valorConta.collectAsStateWithLifecycle().value
     //Pega o valor da conta do viewModel e formata para valores monetários
-    val valorMascarado = formataValorConta(valorConta)
+    val valorMascarado = valorConta.formatarValorEmReal()
 
 
     Column(

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/viewmodels/AdicionarContaViewModel.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/viewmodels/AdicionarContaViewModel.kt
@@ -99,28 +99,28 @@ class AdicionarContaViewModel @Inject constructor(
             icone = valores[1] as BreezeIconsType,
             corIcone = valores[2] as Color,
             corCard = valores[3] as Color,
-            valor = valores[4] as Double,
+            valor = (valores[4] as String).toBigDecimalOrNull() ?: BigDecimal.ZERO,
             categoria = valores[5] as String,
             subCategoria = valores[6] as String,
-            valorParcela = valores[7] as Double,
+            valorParcela = valores[7] as BigDecimal,
             totalParcelas = valores[8] as Int,
             data = valores[9] as LocalDate,
             isParcelada = valores[10] as Boolean,
-            taxaJuros = valores[11] as Double
+            taxaJuros = valores[11] as BigDecimal
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DadosContaUI(
         nome = "",
         icone = BreezeIcons.Unspecified.IconUnspecified,
         corIcone = Color.Unspecified,
         corCard = Color.Unspecified,
-        valor = 0.0,
+        valor = BigDecimal.ZERO,
         categoria = "",
         subCategoria = "",
-        valorParcela = 0.0,
+        valorParcela = BigDecimal.ZERO,
         totalParcelas = 0,
         data = LocalDate.now(),
         isParcelada = false,
-        taxaJuros = 0.0
+        taxaJuros = BigDecimal.ZERO
     ))
 
     init {
@@ -219,7 +219,7 @@ class AdicionarContaViewModel @Inject constructor(
             valorParcela
         }
         else {
-            BigDecimal("0.0")
+            BigDecimal.ZERO
         }
     }
 

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/viewmodels/AdicionarContaViewModel.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/viewmodels/AdicionarContaViewModel.kt
@@ -14,6 +14,7 @@ import com.migueldk17.breeze.data.local.repository.ContaRepository
 import com.migueldk17.breeze.data.local.repository.ParcelaRepository
 import com.migueldk17.breeze.ui.features.adicionarconta.models.DadosContaUI
 import com.migueldk17.breeze.ui.utils.MoneyUtils
+import com.migueldk17.breeze.ui.utils.parseCentavos
 import com.migueldk17.breeze.uistate.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -99,7 +100,7 @@ class AdicionarContaViewModel @Inject constructor(
             icone = valores[1] as BreezeIconsType,
             corIcone = valores[2] as Color,
             corCard = valores[3] as Color,
-            valor = (valores[4] as String).toBigDecimalOrNull() ?: BigDecimal.ZERO,
+            valor = valores[4] as BigDecimal,
             categoria = valores[5] as String,
             subCategoria = valores[6] as String,
             valorParcela = valores[7] as BigDecimal,
@@ -171,7 +172,9 @@ class AdicionarContaViewModel @Inject constructor(
     }
     //Guarda o valor da conta
     fun guardaValorConta(valor: BigDecimal) {
-        _valorConta.value = valor //Olho aqui pq tiramos o /10
+        Log.d(TAG, "guardaValorConta: valor antes da formatação: $valor")
+        _valorConta.value = valor  //Olho aqui pq tiramos o /10
+        Log.d(TAG, "guardaValorConta: valor depois da formatação: ${_valorConta.value}")
     }
 
     fun guardaIsContaParcelada(boolean: Boolean){
@@ -184,8 +187,8 @@ class AdicionarContaViewModel @Inject constructor(
     }
 
     fun guardaPorcentagemJuros(string: String){
-        val valor = string.toBigDecimalOrNull()?.div(BigDecimal.valueOf(100)) ?: BigDecimal.ZERO
-        _taxaDeJurosMensal.value = valor
+        val taxaDeJuros = parseCentavos(string)
+        _taxaDeJurosMensal.value = taxaDeJuros
         Log.d(TAG, "guardaPorcentagemJuros: ${_taxaDeJurosMensal.value}")
     }
 
@@ -202,6 +205,7 @@ class AdicionarContaViewModel @Inject constructor(
     }
 
     private fun guardaValorDaParcela(): BigDecimal{
+        Log.d(TAG, "guardaValorDaParcela: taxa de juros tá assim no view model: ${_taxaDeJurosMensal.value}")
         return if (_taxaDeJurosMensal.value == BigDecimal.ZERO) calculaParcelasSemJuros() else calculaParcelasComJuros()
     }
 

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/viewmodels/AdicionarContaViewModel.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/adicionarconta/viewmodels/AdicionarContaViewModel.kt
@@ -70,8 +70,8 @@ class AdicionarContaViewModel @Inject constructor(
     private val _corCard = MutableStateFlow(Color.Unspecified)
     val corCard: StateFlow<Color> get() = _corCard.asStateFlow()
 
-    private val _valorConta = MutableStateFlow("")
-    val valorConta: StateFlow<String> get() = _valorConta.asStateFlow()
+    private val _valorConta = MutableStateFlow(BigDecimal.ZERO)
+    val valorConta: StateFlow<BigDecimal> get() = _valorConta.asStateFlow()
 
     private val _salvarContasState = MutableStateFlow<UiState<Unit>>(UiState.Loading)
 
@@ -170,7 +170,7 @@ class AdicionarContaViewModel @Inject constructor(
         _corCard.value = color
     }
     //Guarda o valor da conta
-    fun guardaValorConta(valor: String) {
+    fun guardaValorConta(valor: BigDecimal) {
         _valorConta.value = valor //Olho aqui pq tiramos o /10
     }
 
@@ -207,16 +207,11 @@ class AdicionarContaViewModel @Inject constructor(
 
     private fun calculaParcelasSemJuros(): BigDecimal {
         Log.d(TAG, "calculaParcelasSemJuros: Parcelas sem juros acionada")
-        val valorDaConta = BigDecimal(valorConta.value)
+        val valorDaConta = valorConta.value
         val quantidadeDeParcelas = _quantidadeDeParcelas.value
 
         return if (_quantidadeDeParcelas.value > 0){
-            val valorParcela = valorDaConta.divide(
-                BigDecimal.valueOf(quantidadeDeParcelas.toLong()),
-                2,
-                RoundingMode.HALF_EVEN
-            )
-            valorParcela
+            valorDaConta / BigDecimal(quantidadeDeParcelas)
         }
         else {
             BigDecimal.ZERO
@@ -230,7 +225,7 @@ class AdicionarContaViewModel @Inject constructor(
             return BigDecimal.ZERO
         }
 
-        val valorConta = BigDecimal(_valorConta.value)
+        val valorConta = valorConta.value
         val i = _taxaDeJurosMensal.value
         val n = _quantidadeDeParcelas.value
 
@@ -258,7 +253,7 @@ class AdicionarContaViewModel @Inject constructor(
             val name = _nomeConta.value
             val categoria = _categoriaConta.value
             val subCategoria = _subcategoriaConta.value
-            val valor = BigDecimal(_valorConta.value)
+            val valor = _valorConta.value
             val icon = _iconeCardConta.value.enum.toDatabaseValue()
             val colorIcon = _corIcone.value.toDatabaseValue()
             val colorCard = _corCard.value.toDatabaseValue()

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/confirmarpagamento/components/PaymentAmount.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/confirmarpagamento/components/PaymentAmount.kt
@@ -22,7 +22,7 @@ import com.migueldk17.breeze.ui.features.confirmarpagamento.viewmodels.Confirmar
 import com.migueldk17.breeze.ui.theme.Blue
 import com.migueldk17.breeze.ui.theme.NavyBlue
 import com.migueldk17.breeze.ui.utils.MoneyUtils
-import com.migueldk17.breeze.ui.utils.formataValorConta
+import com.migueldk17.breeze.ui.utils.formatarValorEmReal
 
 @Composable
 fun PaymentAmount(
@@ -34,7 +34,7 @@ fun PaymentAmount(
     val icon = state.icon
     val valor = state.valor
     val valorArrendondado = MoneyUtils.arredondarValor(valor)
-    val valorConta = formataValorConta(valorArrendondado)
+    val valorConta = valorArrendondado.formatarValorEmReal()
     val description = if (!haveInstallment) "Pagamento referente a $name" else "Pagamento referente a ${numeroDaParcela}ª parcela de $name"
 
     Column(

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/confirmarpagamento/viewmodels/ConfirmarPagamentoViewModel.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/confirmarpagamento/viewmodels/ConfirmarPagamentoViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import java.math.BigDecimal
 import java.time.LocalDate
 import javax.inject.Inject
 
@@ -50,8 +51,8 @@ class ConfirmarPagamentoViewModel @Inject constructor(
     private val _numeroDaParcela: MutableStateFlow<Int> = MutableStateFlow(1)
     val numeroDaParcela: StateFlow<Int> = _numeroDaParcela.asStateFlow()
 
-    private val _valor = MutableStateFlow(1.0)
-    val valor: StateFlow<Double> = _valor.asStateFlow()
+    private val _valor = MutableStateFlow(BigDecimal.ONE)
+    val valor: StateFlow<BigDecimal> = _valor.asStateFlow()
 
     private val _isLatestInstallment = MutableStateFlow(false)
     val isLatestInstallment: StateFlow<Boolean> = _isLatestInstallment.asStateFlow()
@@ -68,8 +69,8 @@ class ConfirmarPagamentoViewModel @Inject constructor(
         _formaDePagamento.value = value
     }
 
-    fun setValor(double: Double){
-        _valor.value = double
+    fun setValor(valor: BigDecimal){
+        _valor.value = valor
     }
 
     fun setIdDaParcela(long: Long){
@@ -117,7 +118,7 @@ class ConfirmarPagamentoViewModel @Inject constructor(
             if (resultado == 1){
                 movimentacaoRepository.adicionarMovimentacao(
                     MovimentacaoEntity(
-                        valor = -valor,
+                        valor = valor.negate(),
                         descricao = "Pagamento da conta $nome",
                         data = data,
                         contaId = idDaConta,

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/historico/ui/comparativo/HistoricoDoMesComparativo.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/historico/ui/comparativo/HistoricoDoMesComparativo.kt
@@ -29,6 +29,7 @@ import com.migueldk17.breeze.ui.theme.BreezeTheme
 import com.migueldk17.breeze.ui.theme.RedError
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
+import java.math.BigDecimal
 import java.time.LocalDate
 
 @Composable
@@ -43,7 +44,7 @@ fun HistoricoDoMesComparativo(
     val primeiraMovimentacao = MovimentacaoTeste(
         nomeDaConta = "Aluguel do Mês",
         icon = BreezeIcons.Linear.Money.MoneySend,
-        valor = 650.0,
+        valor = BigDecimal("650.00"),
         category = "Moradia",
         date = primeiraData,
         progressBush = Brush.horizontalGradient(
@@ -57,7 +58,7 @@ fun HistoricoDoMesComparativo(
     val segundaMovimentacao = MovimentacaoTeste(
         nomeDaConta = "Salário",
         icon = BreezeIcons.Linear.Money.MoneyRecive,
-        valor = 3500.0,
+        valor = BigDecimal("3500.00"),
         category = "Receita",
         date = segundaData,
         progressBush = Brush.horizontalGradient(
@@ -112,7 +113,7 @@ fun HistoricoDoMesComparativo(
 private data class MovimentacaoTeste(
     val nomeDaConta: String,
     val icon: BreezeIconsType,
-    val valor: Double,
+    val valor: BigDecimal,
     val category: String,
     val date: LocalDate,
     val progressBush: Brush

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/historico/ui/comparativo/components/DestaquesCard.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/historico/ui/comparativo/components/DestaquesCard.kt
@@ -40,7 +40,7 @@ import java.time.LocalDate
 @Composable
 fun DestaquesCard(
     nomeDaConta: String,
-    valor: Double,
+    valor: BigDecimal,
     category: String,
     icon: BreezeIconsType,
     date: LocalDate,
@@ -163,7 +163,7 @@ fun DestaquesCard(
 private data class MovimentacaoTeste(
     val nomeDaConta: String,
     val icon: BreezeIconsType,
-    val valor: Double,
+    val valor: BigDecimal,
     val category: String,
     val date: LocalDate,
     val progressBush: Brush

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/historico/ui/comparativo/components/SaldoDoMesCard.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/historico/ui/comparativo/components/SaldoDoMesCard.kt
@@ -30,6 +30,7 @@ import com.migueldk17.breeze.ui.theme.NavyBlue
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import java.time.LocalDate
+import java.math.BigDecimal
 import java.time.LocalDateTime
 
 
@@ -59,7 +60,7 @@ fun SaldoDoMesCard(
         LinhaDoTempoModel(
             name = "Salário",
             icon = BreezeIcons.Linear.Money.MoneyRecive.enum.name,
-            valor = 1000.0,
+            valor = BigDecimal("1000.00"),
             colorCard = Color(0xFFACE1C1).toArgb(),
             colorIcon = Color(0xFFACE1C1).toArgb(),
             id = 1,
@@ -69,7 +70,7 @@ fun SaldoDoMesCard(
         LinhaDoTempoModel(
             name = "Mercado",
             icon = BreezeIcons.Linear.Shop.Bag2.enum.name,
-            valor = 200.0,
+            valor = BigDecimal("200.00"),
             colorCard = Color(0xFFF69297).toArgb(),
             colorIcon = Color(0xFFF69297).toArgb(),
             id = 2,
@@ -79,7 +80,7 @@ fun SaldoDoMesCard(
         LinhaDoTempoModel(
             name = "Spotify",
             icon = BreezeIcons.Linear.Company.SpotifyLinear.enum.name,
-            valor = 23.90,
+            valor = BigDecimal("23.90"),
             colorCard = Color(0xFFF69297).toArgb(),
             colorIcon = Color(0xFFF69297).toArgb(),
             id = 3,
@@ -89,7 +90,7 @@ fun SaldoDoMesCard(
         LinhaDoTempoModel(
             name = "Compra na Google Play",
             icon = BreezeIcons.Linear.Company.GooglePlayLinear.enum.name,
-            valor = 55.90,
+            valor = BigDecimal("55.90"),
             colorCard = Color(0xFFF69297).toArgb(),
             colorIcon = Color(0xFFF69297).toArgb(),
             id = 4,
@@ -99,7 +100,7 @@ fun SaldoDoMesCard(
         LinhaDoTempoModel(
             name = "Freelancer",
             icon = BreezeIcons.Linear.Money.MoneyRecive.enum.name,
-            valor = 200.0,
+            valor = BigDecimal("200.00"),
             colorCard = Color(0xFFACE1C1).toArgb(),
             colorIcon = Color(0xFFACE1C1).toArgb(),
             id = 5,

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/historico/ui/comparativo/components/TextValue.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/historico/ui/comparativo/components/TextValue.kt
@@ -11,12 +11,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.migueldk17.breeze.ui.components.DescriptionText
 import java.math.BigDecimal
-import kotlin.Double
 
 
 @Composable
 fun TextValue(
-    value: Double,
+    value: BigDecimal,
     modifier: Modifier = Modifier,
     size: TextUnit = 14.sp,
     colors: Color = Color(0xFF1D1D1D)

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/historico/ui/conta/components/ContaPrincipal.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/historico/ui/conta/components/ContaPrincipal.kt
@@ -29,7 +29,7 @@ import com.migueldk17.breeze.ui.features.historico.ui.components.BoxDate
 import com.migueldk17.breeze.ui.features.historico.utils.ShowDetailsCard
 import com.migueldk17.breeze.ui.utils.MoneyUtils
 import com.migueldk17.breeze.ui.utils.formataSaldo
-import com.migueldk17.breeze.ui.utils.formataValorConta
+import com.migueldk17.breeze.ui.utils.formatarValorEmReal
 import java.math.BigDecimal
 
 @Composable
@@ -112,6 +112,6 @@ fun ContaPrincipal(
 internal fun retornaValorTotalArredondado(valorParcela: BigDecimal, totalParcelas: Int): String {
     val valorTotal = valorParcela * BigDecimal(totalParcelas)
     val totalArredondado = MoneyUtils.arredondarValor(valorTotal)
-    val totalFormatado = formataValorConta(totalArredondado)
+    val totalFormatado = totalArredondado.formatarValorEmReal()
     return totalFormatado
 }

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/historico/ui/conta/components/ContaSecundaria.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/historico/ui/conta/components/ContaSecundaria.kt
@@ -31,6 +31,7 @@ import com.migueldk17.breeze.converters.toBreezeIconsType
 import com.migueldk17.breeze.ui.features.historico.model.LinhaDoTempoModel
 import com.migueldk17.breeze.ui.features.historico.utils.ShowDetailsCard
 import com.migueldk17.breeze.ui.utils.formataSaldo
+import java.math.BigDecimal
 import java.time.LocalDateTime
 
 @Composable
@@ -45,7 +46,7 @@ fun ContaSecundaria(
         name = "",
         category = "",
         subCategory = "",
-        valor = 0.0,
+        valor = BigDecimal.ZERO,
         icon = "",
         colorIcon = 0,
         colorCard = 0,

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/paginainicial/ui/components/AdicionarReceitaBottomSheet.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/paginainicial/ui/components/AdicionarReceitaBottomSheet.kt
@@ -37,13 +37,14 @@ import com.migueldk17.breeze.ui.features.paginainicial.viewmodels.PaginaInicialV
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import java.time.LocalDate
+import java.math.BigDecimal
 import java.time.format.DateTimeFormatter
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AdicionarReceitaBottomSheet(
     atualizaBottomSheet: (Boolean) -> Unit,
-    adicionaReceita: (Double, String, LocalDate, String) -> Unit
+    adicionaReceita: (BigDecimal, String, LocalDate, String) -> Unit
 ){
     //Estados para controlar o ModalBottomSheet
      val scope = rememberCoroutineScope()
@@ -144,7 +145,7 @@ fun AdicionarReceitaBottomSheet(
                 onClick = {
                     Log.d(TAG, "AdicionarReceitaBottomSheet: referencia do icone: $icon")
                     adicionaReceita(
-                        saldoInput.toDouble(),
+                        saldoInput.toBigDecimalOrNull() ?: BigDecimal.ZERO,
                         descricaoInput,
                         selectedDate,
                         icon

--- a/app/src/main/java/com/migueldk17/breeze/ui/features/paginainicial/ui/components/BreezeCardConta.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/features/paginainicial/ui/components/BreezeCardConta.kt
@@ -40,7 +40,7 @@ import com.migueldk17.breeze.ui.features.historico.ui.conta.components.retornaVa
 import com.migueldk17.breeze.ui.theme.DeepSkyBlue
 import com.migueldk17.breeze.ui.theme.blackPoppinsLightMode
 import com.migueldk17.breeze.ui.utils.formataSaldo
-import com.migueldk17.breeze.ui.utils.formataValorConta
+import com.migueldk17.breeze.ui.utils.formatarValorEmReal
 import kotlinx.collections.immutable.ImmutableList
 import java.math.BigDecimal
 
@@ -196,7 +196,7 @@ private fun MostraDialogPagarConta(
 
 fun retornaValorNoCard(valor: BigDecimal,parcela: ParcelaEntity?): String {
     val valor = if (parcela == null) {
-        formataValorConta(valor)
+        valor.formatarValorEmReal()
     } else {
         retornaValorTotalArredondado(parcela.valor, parcela.totalParcelas)
     }

--- a/app/src/main/java/com/migueldk17/breeze/ui/utils/Utils.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/utils/Utils.kt
@@ -22,12 +22,12 @@ fun formataSaldo(valor: BigDecimal?): String {
     return "Carregando..."
 }
 
-fun formataValorConta(valor: BigDecimal?): String {
-    return String.format(Locale.getDefault(), "R$: %.2f",
-        valor ?: BigDecimal.ZERO
-    )
+fun parseCentavos(valor: String): BigDecimal {
+    val numero = valor.toBigDecimalOrNull() ?: BigDecimal.ZERO
+    return numero
+        .divide(BigDecimal(100))
+        .setScale(2, RoundingMode.HALF_EVEN)
 }
-
 fun BigDecimal.formatarValorEmReal(): String {
     Log.d(TAG, "formatarValorEmReal: Antes da formatacao $this")
     val format = NumberFormat.getCurrencyInstance(Locale("pt", "BR"))

--- a/app/src/main/java/com/migueldk17/breeze/ui/utils/Utils.kt
+++ b/app/src/main/java/com/migueldk17/breeze/ui/utils/Utils.kt
@@ -2,11 +2,14 @@ package com.migueldk17.breeze.ui.utils
 
 
 import android.content.Context
+import android.content.ContentValues.TAG
+import android.util.Log
 import android.widget.Toast
 import androidx.navigation.NavController
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.text.DecimalFormat
+import java.text.NumberFormat
 import java.time.LocalDate
 import java.util.Locale
 import kotlin.math.pow
@@ -19,7 +22,17 @@ fun formataSaldo(valor: BigDecimal?): String {
     return "Carregando..."
 }
 
-fun formataValorConta(valor: BigDecimal?): String = String.format(Locale.getDefault(), "R$: %.2f", valor)
+fun formataValorConta(valor: BigDecimal?): String {
+    return String.format(Locale.getDefault(), "R$: %.2f",
+        valor ?: BigDecimal.ZERO
+    )
+}
+
+fun BigDecimal.formatarValorEmReal(): String {
+    Log.d(TAG, "formatarValorEmReal: Antes da formatacao $this")
+    val format = NumberFormat.getCurrencyInstance(Locale("pt", "BR"))
+    return format.format(this)
+}
 
 fun traduzData(mes: String): String {
 


### PR DESCRIPTION
### Motivation
- Garantir precisão e segurança em operações financeiras migrando todos os valores monetários remanescentes de `Double` para `BigDecimal` nas camadas de domínio, ViewModel e UI seguindo boas práticas MVVM. 
- Corrigir pontos onde a migração parcial causava inconsistências (parsing, formatação e comparações) e evitar perda de precisão em cálculos de juros e parcelas. 

### Description
- Substituí tipos monetários em estruturas e modelos expostos por UI e domínio, incluindo `DadosContaUI`, `MovimentacaoDomain`, e vários componentes de histórico para usar `BigDecimal` em vez de `Double`.
- Atualizei `AdicionarContaViewModel` para montar `dadosContaUI` convertendo `valorConta` (string) para `BigDecimal` com fallback seguro e para usar `BigDecimal.ZERO` como defaults; também normalizei cálculos de parcela com `BigDecimal` e `RoundingMode.HALF_EVEN`.
- Migrei `ConfirmarPagamentoViewModel` para usar `StateFlow<BigDecimal>` e alterei `setValor` para receber `BigDecimal`, usando `valor.negate()` ao criar `MovimentacaoEntity` de saída.
- Ajustei UI e utilitários: `MoneyVisualTransformation` agora formata usando `BigDecimal`, `AdicionarReceitaBottomSheet` passa `BigDecimal` no callback, e funções de exibição (`Final`, `retornaValorFinal`, `retornaValorTotalArredondado`, `TextValue`, `DestaquesCard`, `SaldoDoMesCard`, `ContaSecundaria`, `HistoricoDoMesComparativo`) foram adaptadas para `BigDecimal` (comparações com `compareTo(BigDecimal.ZERO)` quando necessário).

### Testing
- Executei uma busca com `rg` por ocorrências de `Double`/`toDouble(` no código e verifiquei que apenas comentários legados permaneceram, indicando cobertura do refactor bem-sucedida por busca estática (sucesso).
- Tentei compilar com `./gradlew :app:compileDebugKotlin` para validar a migração, porém a tentativa falhou no ambiente devido ao download do Gradle Wrapper sendo bloqueado por proxy (`HTTP 403`), portanto a compilação automática não pôde ser concluída (falha por limitação de ambiente).
- Verifiquei diffs locais e arquivos modificados para garantir que conversões e chamadas que produziam `Double` foram atualizadas para `BigDecimal` (inspeção estática sem execução de build).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0900dad34832d96db95f1d8e957a8)